### PR TITLE
Add Ability to Delay Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ export const exampleData: ExampleData = {
 
 A boolean variable may be enabled by setting it to either `1`, `yes`, or `true`.
 
-| Environment Variable     | Default | Description                                                                                                              |
-| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `GRPC_PORT`              | 3000    | The port the native server should listen on                                                                              |
-| `GRPC_WEB_PORT`          | 3001    | The port the gRPC web proxy should listen on                                                                             |
-| `ENABLE_DUMMY_ADMIN`     | false   | Whether to enable a dummy admin user                                                                                     |
-| `RESPONSE_DELAY`         | 50      | The number of milliseconds the server's responses are delayed by.                                                        |
-| `LOG_LEVEL`              | `debug` | The log level to use. One of `fatal`, `error`, `warn`, `info`, `debug`, `trace`, or `silent`.                            |
-| `EXAMPLE_DATA_FILE`      | ""      | Relative path to a file inside [src/data/](src/data) containing example data for the mock backend (e.g. standardData.ts) |
+| Environment Variable | Default | Description                                                                                                              |
+| -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `GRPC_PORT`          | 3000    | The port the native server should listen on                                                                              |
+| `GRPC_WEB_PORT`      | 3001    | The port the gRPC web proxy should listen on                                                                             |
+| `ENABLE_DUMMY_ADMIN` | false   | Whether to enable a dummy admin user                                                                                     |
+| `RESPONSE_DELAY`     | 50      | The number of milliseconds the server's responses are delayed by.                                                        |
+| `LOG_LEVEL`          | `debug` | The log level to use. One of `fatal`, `error`, `warn`, `info`, `debug`, `trace`, or `silent`.                            |
+| `EXAMPLE_DATA_FILE`  | ""      | Relative path to a file inside [src/data/](src/data) containing example data for the mock backend (e.g. standardData.ts) |
 
 ## Tooling
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,14 @@ export const exampleData: ExampleData = {
 
 A boolean variable may be enabled by setting it to either `1`, `yes`, or `true`.
 
-| Environment Variable | Default | Description                                                                                                              |
-| -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `GRPC_PORT`          | 3000    | The port the native server should listen on                                                                              |
-| `GRPC_WEB_PORT`      | 3001    | The port the gRPC web proxy should listen on                                                                             |
-| `ENABLE_DUMMY_ADMIN` | false   | Whether to enable a dummy admin user                                                                                     |
-| `LOG_LEVEL`          | `debug` | The log level to use. One of `fatal`, `error`, `warn`, `info`, `debug`, `trace`, or `silent`.                            |
-| `EXAMPLE_DATA_FILE`  | ""      | Relative path to a file inside [src/data/](src/data) containing example data for the mock backend (e.g. standardData.ts) |
+| Environment Variable     | Default | Description                                                                                                              |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `GRPC_PORT`              | 3000    | The port the native server should listen on                                                                              |
+| `GRPC_WEB_PORT`          | 3001    | The port the gRPC web proxy should listen on                                                                             |
+| `ENABLE_DUMMY_ADMIN`     | false   | Whether to enable a dummy admin user                                                                                     |
+| `RESPONSE_DELAY`         | 50      | The number of milliseconds the server's responses are delayed by.                                                        |
+| `LOG_LEVEL`              | `debug` | The log level to use. One of `fatal`, `error`, `warn`, `info`, `debug`, `trace`, or `silent`.                            |
+| `EXAMPLE_DATA_FILE`      | ""      | Relative path to a file inside [src/data/](src/data) containing example data for the mock backend (e.g. standardData.ts) |
 
 ## Tooling
 

--- a/src/interceptors/delaying-interceptor.ts
+++ b/src/interceptors/delaying-interceptor.ts
@@ -1,0 +1,39 @@
+import {
+    ResponderBuilder,
+    ServerInterceptingCall,
+    ServerInterceptingCallInterface,
+    ServerInterceptor,
+} from "@grpc/grpc-js";
+import { ServerMethodDefinition } from "@grpc/grpc-js/build/src/make-client";
+import { LOG } from "../log";
+
+const DEFAULT_DELAY = 50;
+const DELAY = parseInt(process.env.RESPONSE_DELAY ?? DEFAULT_DELAY.toString());
+const ACTIVE_DELAY = isNaN(DELAY) || DELAY < 0 ? DEFAULT_DELAY : DELAY;
+
+if (ACTIVE_DELAY !== DELAY) {
+    LOG.error(
+        {},
+        'The provided response delay "%s" was not a valid non-negative integer. Using %dms instead.',
+        process.env.RESPONSE_DELAY,
+        ACTIVE_DELAY,
+    );
+}
+
+if (ACTIVE_DELAY > 0) {
+    LOG.info("The server is responding %dms delayed.", ACTIVE_DELAY);
+}
+
+// Adds a delay to every response in accordance to an environment variable.
+// Helps testing loading-skeletons in the frontend.
+export const DELAYING_INTERCEPTOR: ServerInterceptor = function <RequestT, ResponseT>(
+    _: ServerMethodDefinition<RequestT, ResponseT>,
+    call: ServerInterceptingCallInterface,
+): ServerInterceptingCall {
+    const responder = new ResponderBuilder()
+        .withSendMessage((message, next) => {
+            setTimeout(() => next(message), ACTIVE_DELAY);
+        })
+        .build();
+    return new ServerInterceptingCall(call, responder);
+};

--- a/src/interceptors/delaying-interceptor.ts
+++ b/src/interceptors/delaying-interceptor.ts
@@ -8,7 +8,8 @@ import { ServerMethodDefinition } from "@grpc/grpc-js/build/src/make-client";
 import { RESPONSE_DELAY_MS } from "../options";
 
 // Adds a delay to every response in accordance to an environment variable.
-// Helps testing loading-skeletons in the frontend.
+// This can be used to better test the loading behavior and the skeletons in the
+// frontend.
 export const DELAYING_INTERCEPTOR: ServerInterceptor = function <RequestT, ResponseT>(
     _: ServerMethodDefinition<RequestT, ResponseT>,
     call: ServerInterceptingCallInterface,

--- a/src/interceptors/delaying-interceptor.ts
+++ b/src/interceptors/delaying-interceptor.ts
@@ -5,24 +5,7 @@ import {
     ServerInterceptor,
 } from "@grpc/grpc-js";
 import { ServerMethodDefinition } from "@grpc/grpc-js/build/src/make-client";
-import { LOG } from "../log";
-
-const DEFAULT_DELAY = 50;
-const DELAY = parseInt(process.env.RESPONSE_DELAY ?? DEFAULT_DELAY.toString());
-const ACTIVE_DELAY = isNaN(DELAY) || DELAY < 0 ? DEFAULT_DELAY : DELAY;
-
-if (ACTIVE_DELAY !== DELAY) {
-    LOG.error(
-        {},
-        'The provided response delay "%s" was not a valid non-negative integer. Using %dms instead.',
-        process.env.RESPONSE_DELAY,
-        ACTIVE_DELAY,
-    );
-}
-
-if (ACTIVE_DELAY > 0) {
-    LOG.info("The server is responding %dms delayed.", ACTIVE_DELAY);
-}
+import { RESPONSE_DELAY_MS } from "../options";
 
 // Adds a delay to every response in accordance to an environment variable.
 // Helps testing loading-skeletons in the frontend.
@@ -32,7 +15,7 @@ export const DELAYING_INTERCEPTOR: ServerInterceptor = function <RequestT, Respo
 ): ServerInterceptingCall {
     const responder = new ResponderBuilder()
         .withSendMessage((message, next) => {
-            setTimeout(() => next(message), ACTIVE_DELAY);
+            setTimeout(() => next(message), RESPONSE_DELAY_MS);
         })
         .build();
     return new ServerInterceptingCall(call, responder);

--- a/src/interceptors/logging-interceptor.ts
+++ b/src/interceptors/logging-interceptor.ts
@@ -8,7 +8,7 @@ import {
 import { Status } from "@grpc/grpc-js/build/src/constants";
 import { ServerMethodDefinition } from "@grpc/grpc-js/build/src/make-client";
 import { isSnowballRService } from "../util";
-import { LOG } from "../main";
+import { LOG } from "../log";
 
 function stripPrefix(value: string, prefix: string) {
     return value.startsWith(prefix) ? value.substring(prefix.length) : value;

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,6 +1,9 @@
 import pino from "pino";
 
 // Initializing the logging
+//
+// Environment variable cannot be moved to `options.ts` due to a cyclical
+// dependency.
 const level = process.env.LOG_LEVEL ?? "debug";
 export const LOG = pino({
     level: level,

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,10 @@
+import pino from "pino";
+
+// Initializing the logging
+const level = process.env.LOG_LEVEL ?? "debug";
+export const LOG = pino({
+    level: level,
+    transport: {
+        target: "pino-pretty",
+    },
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,12 +8,9 @@ import * as path from "path";
 import proxy from "@grpc-web/proxy";
 import { loadExampleData, USERS } from "./model";
 import { UserRole, UserStatus } from "./grpc-gen/user";
-import { isOptionEnabled } from "./util";
 import { DELAYING_INTERCEPTOR } from "./interceptors/delaying-interceptor";
 import { LOG } from "./log";
-
-const PORT = process.env.GRPC_PORT ?? "3000";
-const WEB_PORT = process.env.GRPC_WEB_PORT ?? "3001";
+import { ENABLE_DUMMY_ADMIN, EXAMPLE_DATA_FILE, PORT, WEB_PORT } from "./options";
 
 const ADDRESS = "0.0.0.0";
 const ENDPOINT = `${ADDRESS}:${PORT}`;
@@ -45,7 +42,7 @@ server.bindAsync(
 /* parse environment variables */
 
 // Check, whether the dummy admin user should be added or not
-if (isOptionEnabled(process.env.ENABLE_DUMMY_ADMIN)) {
+if (ENABLE_DUMMY_ADMIN) {
     LOG.warn("Security Risk: dummy admin user enabled!");
     USERS.set("admin@admin", {
         id: "admin@admin",
@@ -62,6 +59,6 @@ if (isOptionEnabled(process.env.ENABLE_DUMMY_ADMIN)) {
 }
 
 // Check, whether a filepath to a file containing example data for the mock backend is set
-if (process.env.EXAMPLE_DATA_FILE) {
-    loadExampleData(process.env.EXAMPLE_DATA_FILE);
+if (EXAMPLE_DATA_FILE !== undefined) {
+    loadExampleData(EXAMPLE_DATA_FILE);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,6 +59,6 @@ if (ENABLE_DUMMY_ADMIN) {
 }
 
 // Check, whether a filepath to a file containing example data for the mock backend is set
-if (EXAMPLE_DATA_FILE !== undefined) {
+if (EXAMPLE_DATA_FILE) {
     loadExampleData(EXAMPLE_DATA_FILE);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,10 +6,10 @@ import { LOGGING_INTERCEPTOR } from "./interceptors/logging-interceptor";
 import { addReflection } from "grpc-server-reflection";
 import * as path from "path";
 import proxy from "@grpc-web/proxy";
-import pino from "pino";
 import { loadExampleData, USERS } from "./model";
 import { UserRole, UserStatus } from "./grpc-gen/user";
 import { isOptionEnabled } from "./util";
+import { LOG } from "./log";
 
 const PORT = process.env.GRPC_PORT ?? "3000";
 const WEB_PORT = process.env.GRPC_WEB_PORT ?? "3001";
@@ -42,15 +42,6 @@ server.bindAsync(
 );
 
 /* parse environment variables */
-
-// Initializing the logging
-const level = process.env.LOG_LEVEL ?? "debug";
-export const LOG = pino({
-    level: level,
-    transport: {
-        target: "pino-pretty",
-    },
-});
 
 // Check, whether the dummy admin user should be added or not
 if (isOptionEnabled(process.env.ENABLE_DUMMY_ADMIN)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import proxy from "@grpc-web/proxy";
 import { loadExampleData, USERS } from "./model";
 import { UserRole, UserStatus } from "./grpc-gen/user";
 import { isOptionEnabled } from "./util";
+import { DELAYING_INTERCEPTOR } from "./interceptors/delaying-interceptor";
 import { LOG } from "./log";
 
 const PORT = process.env.GRPC_PORT ?? "3000";
@@ -24,7 +25,7 @@ proxy({
 }).listen(WEB_PORT);
 
 const server = new grpc.Server({
-    interceptors: [AUTH_INTERCEPTOR, LOGGING_INTERCEPTOR],
+    interceptors: [AUTH_INTERCEPTOR, LOGGING_INTERCEPTOR, DELAYING_INTERCEPTOR],
 });
 server.addService(snowballRDefinition, snowballRService);
 addReflection(server, path.join(__dirname, "schema.ds"));

--- a/src/model.ts
+++ b/src/model.ts
@@ -6,7 +6,7 @@ import { Review } from "./grpc-gen/review";
 import { User } from "./grpc-gen/user";
 import { UserSettings } from "./grpc-gen/user_settings";
 import { toServerUser, getRandomItems } from "./util";
-import { LOG } from "./main";
+import { LOG } from "./log";
 
 export type ServerUser = User & { password: string } & LoginSecret;
 export type ServerProjectPaper = Omit<Project_Paper, "reviews">;

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,115 @@
+import { assert } from "@protobuf-ts/runtime";
+import { LOG } from "./log";
+
+/**
+ * Parses environment variables using a set of functions.
+ * A value is parsed and verified using the according functions.
+ * Every output of this function is guaranteed to pass the `verify` condition.
+ *
+ * If the input is `undefined`, the fallback value is used and `onDefault` is
+ * called.
+ *
+ * If the parsing function throws or returns `undefined`, the fallback value is
+ * used and `onParseFailed` is called.
+ *
+ * If the parsing was successful but the `verify`-condition was violated, the
+ * fallback value is used and `onVerifyFailed` is called.
+ *
+ * If the value was parsed successfully and passed the `verify`-check, it is
+ * used and `onSuccess` is called.
+ */
+function parseOption<T>(
+    str: string | undefined,
+    fallback: T,
+    parse: (str: string) => T | undefined,
+    verify: (val: T) => boolean = () => true,
+    onSuccess: (usedVal: T, usedStr: string) => void = () => {},
+    onParseFailed: (usedVal: T, parsedStr: string) => void = () => {},
+    onVerifyFailed: (usedVal: T, parsedVal: T, parsedStr: string) => void = () => {},
+    onDefault: (fallback: T) => void = () => {},
+): T {
+    assert(verify(fallback));
+
+    if (str === undefined) {
+        onDefault(fallback);
+        return fallback;
+    }
+
+    let parsed;
+    try {
+        parsed = parse(str);
+    } catch {
+        parsed = undefined;
+    }
+
+    if (parsed === undefined) {
+        onParseFailed(fallback, str);
+        return fallback;
+    }
+
+    if (verify(parsed)) {
+        onSuccess(parsed, str);
+        return parsed;
+    } else {
+        onVerifyFailed(fallback, parsed, str);
+        return fallback;
+    }
+}
+
+/**
+ * Parse boolean options from an optional string.
+ * The following values are interpreted as:
+ *   `true`:  "yes", "1", "true"
+ *   `false`: "no", "0", "false"
+ *
+ * Strings are compared case-insensitive, thus for example "YeS" is also
+ * considered to be `true`.
+ */
+function parseBoolOption(str: string | undefined, fallback: boolean): boolean {
+    function parseOptionBool(str: string): boolean | undefined {
+        str = str.toLowerCase();
+        if (["1", "yes", "true"].includes(str)) {
+            return true;
+        } else if (["0", "no", "false"].includes(str)) {
+            return false;
+        } else {
+            return undefined;
+        }
+    }
+
+    return parseOption(str, fallback, parseOptionBool);
+}
+
+export const RESPONSE_DELAY_MS = parseOption(
+    process.env.RESPONSE_DELAY,
+    50,
+    parseInt,
+    (v) => !isNaN(v) && v >= 0,
+    (v) => LOG.info("The server is responding %dms delayed.", v),
+    () => {},
+    (u, _, s) =>
+        LOG.error(
+            'The provided response delay "%s" was not a valid non-negative integer. Using %dms instead.',
+            s,
+            u,
+        ),
+    (v) => LOG.info("The server is responding %dms delayed.", v),
+);
+
+export const PORT = parseOption(
+    process.env.GRPC_PORT,
+    "3000",
+    (s) => s,
+    (s) => !isNaN(parseInt(s)),
+);
+
+export const WEB_PORT = parseOption(
+    process.env.GRPC_WEB_PORT,
+    "3001",
+    (s) => s,
+    (s) => !isNaN(parseInt(s)),
+);
+
+export const ENABLE_DUMMY_ADMIN = parseBoolOption(process.env.ENABLE_DUMMY_ADMIN, false);
+
+export const EXAMPLE_DATA_FILE = parseOption(process.env.EXAMPLE_DATA_FILE, undefined, (s) => s);

--- a/src/options.ts
+++ b/src/options.ts
@@ -101,9 +101,33 @@ function verifyPort(str: string): boolean {
     return !isNaN(port) && port > 0 && port < 1 << 16;
 }
 
-export const PORT = parseOption(process.env.GRPC_PORT, "3000", (s) => s, verifyPort);
+function logVerifyFailedPort(usedVal: string, _: string, parsedStr: string) {
+    LOG.error(
+        'The provided port "%s" was either not a number or not in the range 0 < port < 65535. Using the port %s.',
+        parsedStr,
+        usedVal,
+    );
+}
 
-export const WEB_PORT = parseOption(process.env.GRPC_WEB_PORT, "3001", (s) => s, verifyPort);
+export const PORT = parseOption(
+    process.env.GRPC_PORT,
+    "3000",
+    (s) => s,
+    verifyPort,
+    undefined,
+    undefined,
+    logVerifyFailedPort,
+);
+
+export const WEB_PORT = parseOption(
+    process.env.GRPC_WEB_PORT,
+    "3001",
+    (s) => s,
+    verifyPort,
+    undefined,
+    undefined,
+    logVerifyFailedPort,
+);
 
 export const ENABLE_DUMMY_ADMIN = parseBoolOption(process.env.ENABLE_DUMMY_ADMIN, false);
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -186,18 +186,3 @@ export function anythingUndefined<T extends object>(obj: T): boolean {
         return v == undefined || (typeof v === "object" && anythingUndefined(v));
     });
 }
-
-/**
- * Checks whether the given string indicates that an option is enabled.
- * An option is considered as enabled, if it is set to either:
- * - 1
- * - (y/Y)es
- * - (t/T)rue
- *
- * @param option the input to check
- * @return true, if the given option is set to value listed above, otherwise false
- */
-export function isOptionEnabled(option?: string): boolean {
-    option = option?.toLowerCase() ?? "";
-    return ["1", "yes", "true"].includes(option);
-}


### PR DESCRIPTION
What I have implemented:
- `RESPONSE_DELAY` environment variable
- `DELAYING_INTERCEPTOR` interceptor delaying every response by the provided delay.
- `LOG` constant outsourced into its own file to maintain a correct initialization order.