### PR TITLE
fix/46 change parameters of get next or previous paper

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -1393,14 +1393,15 @@ export const snowballRService: ISnowballR = {
         call: ServerUnaryCall<Id, Project_Paper>,
         callback: sendUnaryData<Project_Paper>,
     ): void {
-        const { projectPaper, projectPapers } = getProjectPaperData(call.request);
-        if (!projectPaper) {
+        const result = getProjectPaperData(call.request);
+        if (!result) {
             callback({
                 code: status.NOT_FOUND,
                 message: "Paper with the given id was not found",
             });
             return;
         }
+        const { projectPaper, projectPapers } = result;
         const nextPaper = projectPapers.find(
             (paper) => parseInt(paper.localId) == parseInt(projectPaper.localId) + 1,
         );
@@ -1418,14 +1419,15 @@ export const snowballRService: ISnowballR = {
         call: ServerUnaryCall<Id, Project_Paper>,
         callback: sendUnaryData<Project_Paper>,
     ): void {
-        const { projectId, projectPaper, projectPapers } = getProjectPaperData(call.request);
-        if (!projectPaper) {
+        const result = getProjectPaperData(call.request);
+        if (!result) {
             callback({
                 code: status.NOT_FOUND,
                 message: "No next paper available.",
             });
             return;
         }
+        const { projectId, projectPaper, projectPapers } = result;
         // Search for the next paper to review
         let stage = projectPaper.stage;
         let currentPaperId = projectPaper.localId;
@@ -1464,14 +1466,15 @@ export const snowballRService: ISnowballR = {
         call: ServerUnaryCall<Id, Project_Paper>,
         callback: sendUnaryData<Project_Paper>,
     ): void {
-        const { projectPaper, projectPapers } = getProjectPaperData(call.request);
-        if (!projectPaper) {
+        const result = getProjectPaperData(call.request);
+        if (!result) {
             callback({
                 code: status.NOT_FOUND,
                 message: "Paper with the given id was not found",
             });
             return;
         }
+        const { projectPaper, projectPapers } = result;
         const nextPaper = projectPapers.find(
             (paper) => parseInt(paper.localId) == parseInt(projectPaper.localId) - 1,
         );

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,6 +3,7 @@ import {
     PAPER_REVIEWS,
     PROJECT_PAPERS,
     PROJECT_PROJECT_PAPERS,
+    PROJECTS,
     REVIEWS,
     ServerProjectPaper,
     ServerUser,
@@ -226,21 +227,26 @@ export function makeResponseAuthMetadata(tokenPair: TokenPair): Metadata {
 
 interface PaperInProjectResult {
     projectId: string;
-    projectPaper?: Project_Paper;
+    projectPaper: Project_Paper;
     projectPapers: Project_Paper[];
 }
 
 /**
- * Searches for the project paper with the given id, the according project and its project papers.
+ * Searches for the project paper with the given global id, its according projectId and its project papers.
  *
- * @param paperId the id of the paper that should be found.
+ * @param paperId the global id of the project paper
  * @returns PaperInProjectResult
  */
-export function getProjectPaperData(paperId: Id): PaperInProjectResult {
-    const projectId = paperId.id.split("-")[0];
-    const projectPapers = PROJECT_PROJECT_PAPERS.get(projectId)!
-        .map((ppp) => PROJECT_PAPERS.get(ppp)!)
-        .map(addProjectPaperReviews);
-    const projectPaper = projectPapers.find((pp) => pp.id === paperId.id);
-    return { projectId, projectPaper, projectPapers };
+export function getProjectPaperData(paperId: Id): PaperInProjectResult | undefined {
+    for (const project of PROJECTS.values()) {
+        const projectId = project.id;
+        const projectPapers = PROJECT_PROJECT_PAPERS.get(projectId)!
+            .map((ppp) => PROJECT_PAPERS.get(ppp)!)
+            .map(addProjectPaperReviews);
+        const projectPaper = projectPapers.find((pp) => pp.id === paperId.id);
+        if (projectPaper) {
+            return { projectId, projectPaper, projectPapers };
+        }
+    }
+    return undefined;
 }


### PR DESCRIPTION
Closes #46 

## What I have made

Due to the fact, that the mock-backend don't habe relations from a `ProjectPaper` to the according `Project` (which will be implemented in the real backend), I have added a loop, that searches for the `Project` the `ProjectPaper` is part of (to implemente the methods `getNextPaper()`, `getNextPaperToReview()` and `getPreviousPaper()` correctly). Thus, it is possible to determine the `ProjectPapers` project without supplying it via the method parameters.