### PR TITLE
Fix 'maxStage' do not update when new project paper is added

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -994,6 +994,11 @@ export const snowballRService: ISnowballR = {
                 1.0,
             ),
         });
+        const project = PROJECTS.get(projectId)!;
+        if (project.maxStage < stage) {
+            project.maxStage = stage;
+            PROJECTS.set(projectId, project);
+        }
         callback(null, project_paper);
     },
     updateProjectPaper: function (


### PR DESCRIPTION
Closes #48

- I added a check to update the 'maxStage' of a project if a project paper with a higher stage number is added to a project