### PR TITLE
Fix bug that received field masks from the frontend are not compatible with the field masks from the mock backend

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -588,12 +588,11 @@ export const snowballRService: ISnowballR = {
             if (existingUser) {
                 return existingUser;
             } else {
-                const newUser: User = User.create({
+                return User.create({
                     id: userId,
                     email: userId,
                     firstName: userId,
                 });
-                return newUser;
             }
         });
 
@@ -641,7 +640,7 @@ export const snowballRService: ISnowballR = {
             return;
         }
 
-        // First, check whether user is a member of the given project
+        // First, check whether the user is a member of the given project
         const projectMembers = MEMBERS.get(projectId)!;
         if (projectMembers.some((member) => member.user?.id == userId)) {
             MEMBERS.set(
@@ -652,7 +651,7 @@ export const snowballRService: ISnowballR = {
             return;
         }
 
-        // If not, check whether user is invited to this project
+        // If not, check whether the user is invited to this project
         const invitations = INVITATIONS.get(userId) ?? [];
         if (invitations.includes(projectId)) {
             INVITATIONS.set(

--- a/src/service.ts
+++ b/src/service.ts
@@ -74,6 +74,7 @@ import {
     addProjectPaperReviews,
     anythingUndefined,
     findFirst,
+    generateUpdateObject,
     getAuthenticated,
     getNextId,
     getProjectPaperData,
@@ -82,7 +83,6 @@ import {
     toUser,
 } from "./util";
 import { randomToken } from "./random";
-import { applyFieldMask } from "protobuf-fieldmask";
 import { Timestamp } from "./grpc-gen/google/protobuf/timestamp";
 import { PartialMessage } from "@protobuf-ts/runtime";
 
@@ -314,11 +314,9 @@ export const snowballRService: ISnowballR = {
         }
 
         const currentUser = USERS.get(user.id)!;
+        const updatedUser = generateUpdateObject(user, mask, "user");
 
-        const update = mask == null ? user : applyFieldMask(user, mask.paths);
-        delete update["id"];
-
-        if (anythingUndefined(update)) {
+        if (anythingUndefined(updatedUser)) {
             callback({
                 code: status.INVALID_ARGUMENT,
                 message: "A provided field specified by the field mask was undefined",
@@ -326,7 +324,7 @@ export const snowballRService: ISnowballR = {
             return;
         }
 
-        User.mergePartial(currentUser, update as PartialMessage<User>);
+        User.mergePartial(currentUser, updatedUser as PartialMessage<User>);
         USERS.set(user.id, currentUser);
 
         callback(null, USERS.get(user.id));
@@ -428,9 +426,9 @@ export const snowballRService: ISnowballR = {
             return;
         }
 
-        const update = mask == null ? userSettings : applyFieldMask(userSettings, mask.paths);
+        const updatedUserSettings = generateUpdateObject(userSettings, mask, "user_settings");
 
-        if (anythingUndefined(update)) {
+        if (anythingUndefined(updatedUserSettings)) {
             callback({
                 code: status.INVALID_ARGUMENT,
                 message: "A provided field specified by the field mask was undefined",
@@ -438,7 +436,10 @@ export const snowballRService: ISnowballR = {
             return;
         }
 
-        UserSettings.mergePartial(currentSettings, update as PartialMessage<UserSettings>);
+        UserSettings.mergePartial(
+            currentSettings,
+            updatedUserSettings as PartialMessage<UserSettings>,
+        );
         USER_SETTINGS.set(user.id, currentSettings);
 
         callback(null, USER_SETTINGS.get(user.id));
@@ -805,10 +806,9 @@ export const snowballRService: ISnowballR = {
         }
 
         const currentProject = PROJECTS.get(project.id)!;
-        const update = mask == null ? project : applyFieldMask(project, mask.paths);
-        delete update["id"];
+        const updatedProject = generateUpdateObject(project, mask, "project");
 
-        if (anythingUndefined(update)) {
+        if (anythingUndefined(updatedProject)) {
             callback({
                 code: status.INVALID_ARGUMENT,
                 message: "A provided field specified by the field mask was undefined",
@@ -816,12 +816,12 @@ export const snowballRService: ISnowballR = {
             return;
         }
 
-        Project.mergePartial(currentProject, update as PartialMessage<Project>);
+        Project.mergePartial(currentProject, updatedProject as PartialMessage<Project>);
         PROJECTS.set(project.id, currentProject);
 
         // Project.mergePartial won't remove deleted fetchers, which is why they are manually removed here
         if (mask?.paths.find((it) => it === "settings.fetchers")) {
-            const specified = Object.keys(update.settings?.fetchers ?? {});
+            const specified = Object.keys(updatedProject.settings?.fetchers ?? {});
             const current = Object.keys(PROJECTS.get(project.id)?.settings?.fetchers ?? {});
             const removedFetchers = current.filter((it) => !specified.find((x) => x == it));
             const fetchers = PROJECTS.get(project.id)?.settings?.fetchers ?? {};
@@ -953,10 +953,9 @@ export const snowballRService: ISnowballR = {
         }
 
         const currentCriterion = CRITERIA.get(criterion.id)!;
-        const update = mask == null ? criterion : applyFieldMask(criterion, mask.paths);
-        delete update["id"];
+        const updatedCriterion = generateUpdateObject(criterion, mask, "criterion");
 
-        if (anythingUndefined(update)) {
+        if (anythingUndefined(updatedCriterion)) {
             callback({
                 code: status.INVALID_ARGUMENT,
                 message: "A provided field specified by the field mask was undefined",
@@ -964,7 +963,7 @@ export const snowballRService: ISnowballR = {
             return;
         }
 
-        Criterion.mergePartial(currentCriterion, update as PartialMessage<Criterion>);
+        Criterion.mergePartial(currentCriterion, updatedCriterion as PartialMessage<Criterion>);
         CRITERIA.set(criterion.id, currentCriterion);
 
         callback(null, CRITERIA.get(criterion.id));
@@ -1076,10 +1075,9 @@ export const snowballRService: ISnowballR = {
         }
 
         const currentProjectPaper = PROJECT_PAPERS.get(projectPaper.id)!;
-        const update = mask == null ? projectPaper : applyFieldMask(projectPaper, mask.paths);
-        delete update["id"];
+        const updatedProjectPaper = generateUpdateObject(projectPaper, mask, "project_paper");
 
-        if (anythingUndefined(update)) {
+        if (anythingUndefined(updatedProjectPaper)) {
             callback({
                 code: status.INVALID_ARGUMENT,
                 message: "A provided field specified by the field mask was undefined",
@@ -1089,7 +1087,7 @@ export const snowballRService: ISnowballR = {
 
         Project_Paper.mergePartial(
             { ...currentProjectPaper, reviews: [] },
-            update as PartialMessage<Project_Paper>,
+            updatedProjectPaper as PartialMessage<Project_Paper>,
         );
         PROJECT_PAPERS.set(projectPaper.id, currentProjectPaper);
 
@@ -1186,10 +1184,9 @@ export const snowballRService: ISnowballR = {
         }
 
         const currentReview = REVIEWS.get(review.id)!;
-        const update = mask == null ? review : applyFieldMask(review, mask.paths);
-        delete update["id"];
+        const updatedReview = generateUpdateObject(review, mask, "review");
 
-        if (anythingUndefined(update)) {
+        if (anythingUndefined(updatedReview)) {
             callback({
                 code: status.INVALID_ARGUMENT,
                 message: "A provided field specified by the field mask was undefined",
@@ -1197,7 +1194,7 @@ export const snowballRService: ISnowballR = {
             return;
         }
 
-        Review.mergePartial(currentReview, update as PartialMessage<Review>);
+        Review.mergePartial(currentReview, updatedReview as PartialMessage<Review>);
         REVIEWS.set(review.id, currentReview);
 
         callback(null, REVIEWS.get(review.id));
@@ -1266,10 +1263,9 @@ export const snowballRService: ISnowballR = {
         }
 
         const currentPaper = PAPERS.get(paper.id)!;
-        const update = mask == null ? paper : applyFieldMask(paper, mask.paths);
-        delete update["id"];
+        const updatedPaper = generateUpdateObject(paper, mask, "paper");
 
-        if (anythingUndefined(update)) {
+        if (anythingUndefined(updatedPaper)) {
             callback({
                 code: status.INVALID_ARGUMENT,
                 message: "A provided field specified by the field mask was undefined",
@@ -1277,7 +1273,7 @@ export const snowballRService: ISnowballR = {
             return;
         }
 
-        Paper.mergePartial(currentPaper, update as PartialMessage<Paper>);
+        Paper.mergePartial(currentPaper, updatedPaper as PartialMessage<Paper>);
         PAPERS.set(paper.id, currentPaper);
 
         callback(null, PAPERS.get(paper.id));

--- a/src/util.ts
+++ b/src/util.ts
@@ -266,6 +266,7 @@ function snakeToCamelCase(s: string): string {
  * Optionally, remove a prefix from the field names.
  *
  * @param obj - The object for which the field mask should be applied.
+ * @param mask - The field mask containing the paths to update.
  * @param prefix - An optional string prepended to each field path and should be deleted.
  */
 export function generateUpdateObject<T>(
@@ -279,6 +280,8 @@ export function generateUpdateObject<T>(
         mask?.paths
             .filter((p) => p.startsWith(prefixToDelete))
             .map((p) => p.slice(prefixToDelete.length))
+            // filter(Boolean) is needed to remove empty strings after the split, e.g. "foo.bar."
+            // becomes ["foo", "bar"] instead of ["foo", "bar", ""]
             .map((path) => path.split(".").filter(Boolean).map(snakeToCamelCase).join(".")) ?? [];
 
     const updatedObject = mask == null ? obj : applyFieldMask(obj, parsedFieldMask);

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,6 +16,8 @@ import { PaperDecision, Project_Paper, ReviewDecisionMatrix_Pattern } from "./gr
 import { ReviewDecision } from "./grpc-gen/review";
 import * as cookie from "cookie";
 import { Id } from "./grpc-gen/base";
+import { FieldMask } from "./grpc-gen/google/protobuf/field_mask";
+import { applyFieldMask, WithFieldMask } from "protobuf-fieldmask";
 
 /**
  * Checks whether a string is empty
@@ -249,4 +251,40 @@ export function getProjectPaperData(paperId: Id): PaperInProjectResult | undefin
         }
     }
     return undefined;
+}
+
+/**
+ * Convert a string from snake_case-style to camelCase-style.
+ */
+function snakeToCamelCase(s: string): string {
+    return s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+/**
+ * Applies a FieldMask object to a given object and build a partial object.
+ *
+ * Optionally, remove a prefix from the field names.
+ *
+ * @param obj - The object for which the field mask should be applied.
+ * @param prefix - An optional string prepended to each field path and should be deleted.
+ */
+export function generateUpdateObject<T>(
+    obj: T,
+    mask?: FieldMask,
+    prefix?: string,
+): WithFieldMask<T> {
+    const prefixToDelete = prefix ? `${prefix}.` : "";
+
+    const parsedFieldMask =
+        mask?.paths
+            .filter((p) => p.startsWith(prefixToDelete))
+            .map((p) => p.slice(prefixToDelete.length))
+            .map((path) => path.split(".").filter(Boolean).map(snakeToCamelCase).join(".")) ?? [];
+
+    const updatedObject = mask == null ? obj : applyFieldMask(obj, parsedFieldMask);
+    if ("id" in updatedObject) {
+        delete updatedObject["id"];
+    }
+
+    return updatedObject;
 }


### PR DESCRIPTION
Closes #59

- I added a helper function `generateUpdateObject` to parse the field masks and generate the update objects